### PR TITLE
sed portability update

### DIFF
--- a/modules/ROOT/pages/appsody-deploy.adoc
+++ b/modules/ROOT/pages/appsody-deploy.adoc
@@ -95,7 +95,7 @@ yq w -i app-deploy-remote.yaml spec.createKnativeService true
 Deploy the application, by replacing the image location to use the local service for the docker-registry
 [source, bash]
 ----
-sed -i -e 's#applicationImage: .*$#applicationImage: '"docker-registry.default.svc:5000/${NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}"'#g' ${APP_DEPLOY_YAML}
+sed -i'.bak' -e 's#applicationImage: .*$#applicationImage: '"docker-registry.default.svc:5000/${NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}"'#g' ${APP_DEPLOY_YAML} && rm ${APP_DEPLOY_YAML}.bak
 oc apply -f ${APP_DEPLOY_YAML} -n ${NAMESPACE}
 ----
 
@@ -131,12 +131,13 @@ Run the following script in your terminal to create the two files `.env` and `de
 APP_DEPLOY_YAML=app-deploy-remote.yaml
 appsody deploy --generate-only
 mv app-deploy.yaml ${APP_DEPLOY_YAML}
+APP_NAME=$(yq r ${APP_DEPLOY_YAML} metadata.name)
 
 cat <<EOF >.env
 DOCKER_REGISTRY=$(oc get route docker-registry -n default -o jsonpath="{.spec.host}")
 NAMESPACE=$(oc project -q)
 APP_DEPLOY_YAML=${APP_DEPLOY_YAML}
-APP_NAME=$(yq r ${APP_DEPLOY_YAML} metadata.name)
+APP_NAME=${APP_NAME}
 IMAGE_NAME=${APP_NAME}
 APP_KNATIVE=false
 EOF
@@ -163,7 +164,7 @@ appsody deploy \
   --push \
   -n \${NAMESPACE} \${APP_KNATIVE_FLAG}
 
-sed -i '' -e 's#applicationImage: .*\$#applicationImage: '"docker-registry.default.svc:5000/\${NAMESPACE}/\${IMAGE_NAME}:\${IMAGE_TAG}"'#g' \${APP_DEPLOY_YAML}
+sed -i'.bak' -e 's#applicationImage: .*\$#applicationImage: '"docker-registry.default.svc:5000/\${NAMESPACE}/\${IMAGE_NAME}:\${IMAGE_TAG}"'#g' \${APP_DEPLOY_YAML} && rm \${APP_DEPLOY_YAML}.bak
 
 oc apply -f \${APP_DEPLOY_YAML} -n \${NAMESPACE}
 


### PR DESCRIPTION
Updated `sed` examples with more portable syntax fixes #64 .  Example set of commands to create `.env` file and `deploy.sh` file adjusted to set `APP_NAME` before using the here doc to create `.env`. Existing command resulted in `IMAGE_NAME` being empty.
